### PR TITLE
Fix All catch blocks

### DIFF
--- a/routers/userRouter.js
+++ b/routers/userRouter.js
@@ -17,14 +17,22 @@ const auth = require('../midlewares/auth');
 module.exports = userRoute;
 
 //return all users   
-userRoute.get('/', async(req, res) => {
+userRoute.get('/', async(req, res, next) => {
   try {
     const users = await User.find({}, {password : 0}).exec();
     res.send(users);
     res.statusCode = 200;
   } catch (error) {
-    res.send(error);
-    res.statusCode = 422;
+    // res.send(error); // the response ends here
+    // //because res.send() : sends a response and ends it as well
+    // res.statusCode = 422; // So, This line is unreachable
+
+    // So u can do 
+    res.status(422).send(error);
+
+    // or i prefer pass this error to the error handling middleware
+    // by send it as a parameter to next(error)
+    next(error);
   }
 });
 


### PR DESCRIPTION
The line `res.statusCode = 422;` in all catch blocks is unreachable.
because `send()` sends response and ends it as well, so any code beneath it is unreachable 
u can use `res.status().send()` to set a status code for the response
or even pass the error to the error handling middleware and handle everything there